### PR TITLE
Rename master branch to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,6 @@ Before making a contribution, it is important to make sure that the change you w
 3. Ensure that your commits are squashed.  See [working with git](https://playframework.com/documentation/latest/WorkingWithGit) for more information.
 4. Submit a pull request.
 
-If the pull request does not meet the above requirements then the code should **not** be merged into master, or even reviewed - regardless of how good or important it is. No exceptions.
+If the pull request does not meet the above requirements then the code should **not** be merged into main, or even reviewed - regardless of how good or important it is. No exceptions.
 
 The pull request will be reviewed according to the [implementation decision process](https://playframework.com/community-process#Implementation-decisions).


### PR DESCRIPTION
@SethTisue and @ihostage already renamed the `master` branch in some play repos:
* https://github.com/playframework/cachecontrol/pull/163
* https://github.com/playframework/play-file-watch/pull/136
* https://github.com/playframework/play-json/pull/598
* https://github.com/playframework/play-soap/pull/282
* https://github.com/playframework/play-ws/pull/597
* https://github.com/playframework/twirl/pull/416

Now that we are centralising configs in the [`.github`](https://github.com/playframework/.github) repo it's a good idea that all repos have the same default branch name.

To change to `main` locally (if the remote to this repo is called `upstream`):
```sh
git branch -m master main # rename master to main (actually "move")
git fetch upstream
git branch -u upstream/main main # set upstream
git remote set-head upstream -a # make sure HEAD is set correctly for this remote (autodetect)
```