### PR TITLE
Release draft templates for major/minor/patch releases

### DIFF
--- a/.github/release-drafts/base.yml
+++ b/.github/release-drafts/base.yml
@@ -1,26 +1,21 @@
 name-template: 'Version $RESOLVED_VERSION'
-tag-template: '$NEXT_MINOR_VERSION'
+tag-template: '$RESOLVED_VERSION'
 filter-by-commitish: true
-version-resolver:
-  default: minor
-
 change-template: '- $TITLE #$NUMBER by @$AUTHOR'
 template: |
   ## Changes
 
   $CHANGES
 
+footer: |
   ## :heart: Thanks to our premium sponsors!
-
   <div align="center">
     <a href="https://informaticon.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/61220b8306493af6a21b7db17de7f4b2-informaticon-logo-full-color.png" width="250"></a>
     <a href="https://cedarlakeventures.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/bec2b526c9ce52c051f9089a10044867-cedar-lake-ventures.png" width="250"></a>
     <a href="https://iterable.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/61ddb4c3665b621e6672181f97196748-iterable.png" width="250"></a>
   </div>
-
   If you find this OSS project useful for work, please consider asking your company to support it by <a href="https://www.playframework.com/sponsors">becoming a sponsor</a>.
   You can also individually sponsor the project by <a href="https://www.playframework.com/sponsors">becoming a backer</a>.
-
   <div align="center">
     <a href="https://opencollective.com/playframework" target="_blank">
       <img src="https://opencollective.com/playframework/donate/button@2x.png?color=blue" width="250" />

--- a/.github/release-drafts/increasing-major-version.yml
+++ b/.github/release-drafts/increasing-major-version.yml
@@ -1,0 +1,4 @@
+tag-template: '$NEXT_MAJOR_VERSION'
+version-resolver:
+  default: major
+_extends: .github:.github/release-drafts/base.yml

--- a/.github/release-drafts/increasing-minor-version.yml
+++ b/.github/release-drafts/increasing-minor-version.yml
@@ -1,0 +1,4 @@
+tag-template: '$NEXT_MINOR_VERSION'
+version-resolver:
+  default: minor
+_extends: .github:.github/release-drafts/base.yml

--- a/.github/release-drafts/increasing-patch-version.yml.yml
+++ b/.github/release-drafts/increasing-patch-version.yml.yml
@@ -1,0 +1,4 @@
+tag-template: '$NEXT_PATCH_VERSION'
+version-resolver:
+  default: patch
+_extends: .github:.github/release-drafts/base.yml

--- a/.github/release-drafts/minor-release.yml
+++ b/.github/release-drafts/minor-release.yml
@@ -1,5 +1,0 @@
-name-template: '???'
-tag-template: '$NEXT_PATCH_VERSION'
-version-resolver:
-  default: patch
-_extends: .github:.github/release-drafts/major-release.yml


### PR DESCRIPTION
Now that release drafter fixed bugs, added the header/footer feature and finally can correctly `_extend` other drafts ([see this comment](https://github.com/playframework/.github/pull/3#issuecomment-1027361907)), we can centralise the config in this `.github` repo.