### PR TITLE
Add workflow "Mark Pull Request as Ready To Merge"

### DIFF
--- a/.github/workflows/rtm.yml
+++ b/.github/workflows/rtm.yml
@@ -1,0 +1,12 @@
+name: Mark Pull Request as Ready To Merge
+
+on:
+  workflow_call:
+
+jobs:
+  cmd:
+    name: Ready To Merge
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Ready To Merge
+        run: echo 'Ready To Merge'

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a few configurations of GitHub features. For example a 
 * [Java/Scala matrix SBT task](#javascala-matrix-sbt-task)
 * [Publishing to Sonatype](#publishing-to-sonatype)
 * [Validate Binary Compatibility](#validate-binary-compatibility)
+* [Mark Pull Request as Ready To Merge](#mark-pull-request-as-ready-to-merge)
 
 ### Single SBT task
 
@@ -149,6 +150,29 @@ This workflow is used for validate binary compatibility the current version.
 
 ```yaml
 uses: playframework/.github/.github/workflows/binary-check.yml@v1
+```
+
+### Mark Pull Request as Ready To Merge
+
+This workflow is used for mark pull request as ready to merge and **should be last** in the workflows chain.
+
+:warning: For using this workflow don't forget to configure the `needs` ([GA docs](https://docs.github.com/en/actions/using-workflows/advanced-workflow-features#creating-dependent-jobs)) attribute to make this workflow run last.
+
+**Path**: [`.github/workflows/rtm.yml`](.github/workflows/rtm.yml)
+
+**Image**: [Ubuntu 20.04](https://hub.docker.com/layers/ubuntu/library/ubuntu/20.04/images/sha256-57df66b9fc9ce2947e434b4aa02dbe16f6685e20db0c170917d4a1962a5fe6a9?context=explore)
+
+
+**No Parameters**
+
+**How to use**:
+
+```yaml
+needs: # Should be latest
+  - "check-code-style"
+  - "..."
+  - "tests"
+uses: playframework/.github/.github/workflows/rtm.yml@v1
 ```
 
 ## GitHub Actions Starter workflows


### PR DESCRIPTION
**Goal**: unify configuration of Mergify and use one special marker for merging PRs automatically.

With this workflow our Mergify configuration in every repo will be very similar and when Mergify will add feature [fallback to organization (#4050)](https://github.com/Mergifyio/mergify-engine/pull/4050), we will can to drop all or change their to singleline `_extend`.