### PR TITLE
Provide CACHE_HIT_COURSIER (`steps` is not available from caller workflow)

### DIFF
--- a/.github/workflows/binary-check.yml
+++ b/.github/workflows/binary-check.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Coursier Cache
         id: coursier-cache
-        uses: coursier/cache-action@v6.3
+        uses: coursier/cache-action@v6.3.1
 
       - name: Install Adoptium Temurin OpenJDK
         uses: coursier/setup-action@v1.2.0-M3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Coursier Cache
         id: coursier-cache
-        uses: coursier/cache-action@v6.3
+        uses: coursier/cache-action@v6.3.1
 
       - name: Install Adoptium Temurin OpenJDK
         uses: coursier/setup-action@v1.2.0-M3

--- a/.github/workflows/sbt-matrix.yml
+++ b/.github/workflows/sbt-matrix.yml
@@ -59,6 +59,9 @@ jobs:
         id: coursier-cache
         uses: coursier/cache-action@v6.3.1
 
+      - name: Saving cache-hit-coursier env variable
+        run: echo 'CACHE_HIT_COURSIER=${{ steps.coursier-cache.outputs.cache-hit-coursier }}' >> $GITHUB_ENV
+
       - name: Custom Cache
         uses: actions/cache@v2
         if: ${{ inputs.cache-key != '' && inputs.cache-path != '' }}

--- a/.github/workflows/sbt-matrix.yml
+++ b/.github/workflows/sbt-matrix.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Coursier Cache
         id: coursier-cache
-        uses: coursier/cache-action@v6.3
+        uses: coursier/cache-action@v6.3.1
 
       - name: Custom Cache
         uses: actions/cache@v2

--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -46,6 +46,9 @@ jobs:
         id: coursier-cache
         uses: coursier/cache-action@v6.3.1
 
+      - name: Saving cache-hit-coursier env variable
+        run: echo 'CACHE_HIT_COURSIER=${{ steps.coursier-cache.outputs.cache-hit-coursier }}' >> $GITHUB_ENV
+
       - name: Custom Cache
         uses: actions/cache@v2
         if: ${{ inputs.cache-key != '' && inputs.cache-path != '' }}

--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Coursier Cache
         id: coursier-cache
-        uses: coursier/cache-action@v6.3
+        uses: coursier/cache-action@v6.3.1
 
       - name: Custom Cache
         uses: actions/cache@v2


### PR DESCRIPTION
Tested in https://github.com/playframework/playframework/pull/11257
We can revert to version `...@v6.3` later again.