### PR TITLE
Don't require secrets, otherwise we can't use `secrets: inherit`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,10 +36,10 @@ jobs:
       - name: Publish artifacts
         run: sbt ci-release
         env:
-          SONATYPE_USERNAME: ${{ secrets.username }}
-          SONATYPE_PASSWORD: ${{ secrets.password }}
-          PGP_PASSPHRASE: ${{ secrets.pgp_passphrase }}
-          PGP_SECRET: ${{ secrets.pgp_secret }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
 
       - name: Cleanup before cache
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,15 +11,6 @@ on:
         type: string
         required: false
         default: 8
-    secrets:
-      username:
-        required: true
-      password:
-        required: true
-      pgp_passphrase:
-        required: true
-      pgp_secret:
-        required: true
 
 jobs:
   cmd:


### PR DESCRIPTION
When using `secrets: inherit` we can't make the secrets required in the reusable workflow, otherwise we get an error like [this one](https://github.com/playframework/twirl/actions/runs/2283859753):

> Secret username is required, but not provided while calling.

Tested here: https://github.com/playframework/twirl/runs/6329238847?check_suite_focus=true