### PR TITLE
Don't mention @mergify in release notes anymore

### DIFF
--- a/.github/release-drafts/base.yml
+++ b/.github/release-drafts/base.yml
@@ -2,6 +2,9 @@ name-template: 'Version $RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 filter-by-commitish: true
 change-template: '- #$NUMBER $TITLE by @$AUTHOR'
+replacers:
+  - search: ' by @mergify'
+    replace: ''
 template: |
   ## Changes
 


### PR DESCRIPTION
Eventually fixes https://github.com/playframework/play-meta/issues/216

We do mention the original author of a pull request now: https://github.com/playframework/playframework/blob/7f64632ddb96e8392a64c409075c94b132cd7e53/.mergify.yml#L4

but mergify is still mentioned:
<kbd><img width="600" src="https://user-images.githubusercontent.com/644927/195731183-df234d45-4967-4cf5-9e87-7b809b2d153b.png" /></kbd>

Details: https://github.com/release-drafter/release-drafter/#replacers

Because release notes will be generated on push workflows, I think it's ok to just merge this pull request and later we will see if it worked. Of course we could also temporary change the workflow version `...@rm-by-mergify`in a main branch of a repo but not sure if that is worth it. WDYT @ihostage?