### PR TITLE
Clean up matrix json (no whitespaces etc.)

### DIFF
--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -71,6 +71,8 @@ jobs:
         matrix+="\"include\":$(echo -n '${{ inputs.include }}'),"
         matrix+="\"exclude\":$(echo -n '${{ inputs.exclude }}')"
         matrix+="}"
+        # Cleanup JSON (no unnecessary whitespaces, etc.)
+        matrix=$(jq -n -c "$matrix")
         echo $matrix
         echo "matrix=$matrix" >> $GITHUB_OUTPUT
   cmd:


### PR DESCRIPTION
Fixes problem described in https://github.com/playframework/.github/pull/46#issuecomment-1285269979
In antory.yml we don't need to fix it because the output is not a json.