### PR TITLE
Our "own" Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,10 +1,115 @@
-All repositories in these organizations:
+<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->
 
-* [lightbend](https://github.com/lightbend)
-* [akka](https://github.com/akka)
-* [lagom](https://github.com/lagom)
-* [playframework](https://github.com/playframework)
-* [sbt](https://github.com/sbt)
-* [slick](https://github.com/slick)
+# Play Framework Code of Conduct
 
-are covered by the Lightbend Community Code of Conduct: https://www.lightbend.com/conduct
+We are committed to providing a friendly, safe and welcoming environment for all, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, sexual identity and orientation, or other such characteristics.
+
+### Our Standards
+
+**Whether you’re a regular contributor or a newcomer, we care about making this community a welcoming and safe place for you and we’ve got your back.**
+
+As a member of the community, you agree to the following:
+
+**Encouraged:**
+
+- **Be kind and courteous.** We treat our fellow community members with the empathy, respect and dignity all humans deserve. Keep in mind that public communication is received by many people you don’t know, so before sending a message please ask yourself whether someone from a different context would misunderstand it.
+- **Respect differences of opinion** and remember that every design or implementation choice carries a trade-off and numerous costs. There is seldom a single right answer; we will find the best solutions by engaging in constructive discussion, with everybody bringing their unique viewpoint and experience to the table.
+- **Remember that everyone was new to Scala at some point.** We want to encourage newcomers to join our community and learn the Scala language and ecosystem. Always assume good intentions and a willingness to learn, just as you are willing to evolve your own opinion as you gain new insights.
+
+**Discouraged:**
+
+- Keep unstructured critique to a minimum. We encourage sharing ideas and perspectives, so please ensure that your feedback is constructive and relevant. If you have solid ideas you want to experiment with, make a fork and see how it works.
+- Avoid aggressive and micro-aggressive behavior, such as unconstructive criticism, providing corrections that do not improve the conversation, repeatedly interrupting or talking over someone else, feigning surprise at someone’s lack of knowledge or awareness about a topic, or subtle prejudice (for example, comments like “That’s so easy my grandmother could do it.”). For more examples of this kind of behavior, [see the Recurse Center's user manual](https://www.recurse.com/manual#sec-environment).
+- We will exclude you from interaction if you insult, demean or harass anyone. See [examples of unacceptable behavior](#examples-of-unacceptable-behavior) below. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
+- Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member's behavior, please [contact the moderation team](#contact) immediately.
+- Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
+
+### Moderation
+
+These are the policies for upholding our community’s standards of conduct. If
+you feel that a thread needs moderation, please
+[contact the moderation team](#contact).
+
+- Remarks that violate the above code of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful or aggressive manner.)
+- Moderators will warn users who make remarks inconsistent with the above code of conduct.
+- If the warning is unheeded, the user will be “kicked,” i.e., kicked out of the communication channel to cool off.
+- If the user comes back and continues to make trouble, they will be banned, i.e., indefinitely excluded.
+- Moderators may choose at their discretion to un-ban the user if it was a first offense and they if they make suitable amends with the offended party.
+- If you think a moderator action is unjustified, please take it up with that moderator, or with a different moderator, in private. Complaints about moderation in-channel are not allowed.
+- Moderators are held to a higher standard than other community members. If a moderator acts inappropriately, they should expect less leeway than others.
+
+In the Play Framework community we strive to go the extra step to look out for each
+other. Don’t just aim to be technically unimpeachable; try to be your best self.
+In particular, avoid exacerbating offensive or sensitive issues, particularly if
+they’re off-topic; this all too often leads to unnecessary fights, hurt
+feelings, and damaged trust; worse, it can drive people away from the community
+entirely.
+
+If someone takes issue with something you said or did, resist the urge to be
+defensive. Rather, stop the offending behavior, apologize, and be sensitive
+thereafter. Even if you feel you were misinterpreted or unfairly accused,
+chances are good there was something you could’ve communicated better — remember
+that it’s your responsibility to make your fellow community members comfortable.
+We are all here first and foremost because we want to talk about cool
+technology, and everyone wants to get along in doing so. People are generally
+eager to assume good intent and forgive.
+
+### Domain
+
+The enforcement policies listed above apply to all official Play Framework channels, including:
+
+* GitHub discussion forums
+* Chat rooms under the "Play Framework" Discord server
+* Mailing lists
+* GitHub repositories under the [`playframework` organization](https://github.com/playframework)
+* Play Framework video streams ([Twitch](https://www.twitch.tv/playframework) and [YouTube](https://www.youtube.com/channel/UCRp6QDm5SDjbIuisUpxV9cg))
+
+For other projects adopting the Play Framework Code of Conduct, please contact the maintainers of
+those projects for enforcement. If you wish to use this code of conduct for your
+own project, consider explicitly mentioning your moderation policy or making a
+copy with your own moderation policy so as to avoid confusion.
+
+### Contact
+
+For CoC-related questions or to report possible violations on the channels
+listed above,
+
+* contact one of the moderators active on that channel if you can identify them, or
+* send an e-mail to [contact@playframework.com](mailto:contact@playframework.com), which forwards to members of the Play Framework steering committee
+* send an e-mail to one of the steering committee members if you want to choose who you are talking to. The current members can by found on [this page](https://www.playframework.com/sponsors).
+
+### Examples of unacceptable behavior
+
+Behavior that will lead to exclusion includes the following points, inspired by the definition of
+“Unacceptable Behavior” in the [Citizen Code of Conduct](http://citizencodeofconduct.org/):
+
+* Violence, threats of violence or violent language directed against another person.
+* Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+* Posting or displaying sexually explicit or violent material.
+* Posting or threatening to post other people’s personally identifying information ("doxing").
+* Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
+* Inappropriate photography or recording.
+* Inappropriate physical contact. You should have someone’s consent before touching them.
+* Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
+* Deliberate intimidation, stalking or following (online or in person).
+* Advocating for, or encouraging, any of the above behavior.
+* Sustained disruption of community events, including talks and presentations.
+
+### Credits
+
+Identical to the Scala Code of Conduct [as published on
+scala-lang.org](https://www.scala-lang.org/conduct/), with Domain and
+Contact sections replaced by Play Framework channels and admins.
+
+Adapted from and/or inspired by multiple successful Codes of Conduct, including:
+
+* [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct)
+* [The Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling)
+* [The Contributor Covenant v1.4.0](http://contributor-covenant.org/version/1/4/)
+* [The Recurse Center's User Manual](https://www.recurse.com/manual#sec-environment)
+* [The 18F Code of Conduct](https://18f.gsa.gov/code-of-conduct/)
+* [Citizen Code of Conduct](http://citizencodeofconduct.org/)
+
+### License
+
+This Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike license](https://creativecommons.org/licenses/by-sa/3.0/).


### PR DESCRIPTION
Fixes https://github.com/playframework/play-meta/issues/191

Like suggested by Greg this is just a copy of the CoC used by Scala, Lightbend and Typelevel. I basically just replaced contact details and the domains list. Nothing special.