### PR TITLE
Set ReservedCodeCacheSize=512m when releasing Play 2.8

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -138,7 +138,7 @@ When ready:
   - Make sure you are using **JDK8** to build and release.
   - Ccheckout the branch you want to release and check that the commit you want to release has a green build in CI
   - Tag the commit, eg: (`git tag -s x.y.z`). The projects are using sbt-dynver, so tagging first is important in order to get the right version number. Play is NOT using tag prefixes (eg: v1.0.2), it uses 1.0.2 instead and dynver is configured as such.
-  - Run `sbt release`
+  - Run `sbt -J-XX:ReservedCodeCacheSize=512m release`
   - At the end of the release, you must push the tag.
  - Check the corresponding release page in GitHub, adapt the release notes as needed and published it.
 


### PR DESCRIPTION
Got the warning 
```
OpenJDK 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.
OpenJDK 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=
CodeCache: size=131072Kb used=120457Kb max_used=122886Kb free=10614Kb
 bounds [0x0000ffff20000000, 0x0000ffff28000000, 0x0000ffff28000000]
 total_blobs=33203 nmethods=32314 adapters=787
 compilation: disabled (not enough contiguous free space left)
```