### PR TITLE
Use latest `6.x` release of `coursier/cache-action`

### DIFF
--- a/.github/workflows/binary-check.yml
+++ b/.github/workflows/binary-check.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Coursier Cache
         id: coursier-cache
-        uses: coursier/cache-action@v6.3
+        uses: coursier/cache-action@v6
 
       - name: Install Adoptium Temurin OpenJDK
         uses: coursier/setup-action@v1

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Coursier Cache
         id: coursier-cache
-        uses: coursier/cache-action@v6.3
+        uses: coursier/cache-action@v6
 
       - name: Custom Cache
         uses: actions/cache@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Coursier Cache
         id: coursier-cache
-        uses: coursier/cache-action@v6.3
+        uses: coursier/cache-action@v6
 
       - name: Install Adoptium Temurin OpenJDK
         uses: coursier/setup-action@v1


### PR DESCRIPTION
Current version generate a many warnings. For example [4014115839](https://github.com/playframework/playframework/actions/runs/4014115839)

This fix was checked in this run [4015390504](https://github.com/playframework/playframework/actions/runs/4015390504)
GHA warnings is gone 😄 