### PR TITLE
Remove CiviForm from sponsors

### DIFF
--- a/.github/release-drafts/base.yml
+++ b/.github/release-drafts/base.yml
@@ -18,7 +18,6 @@ footer: |
     <a href="https://cedarlakeventures.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/bec2b526c9ce52c051f9089a10044867-cedar-lake-ventures.png" width="250"></a>
     <a href="https://nulab.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/6152e584aa8625eedca1c4accf8f8b63-nulab_logo_color.png" width="250"></a>
     <a href="https://pronto.net/"><img src="https://www.playframework.com/assets/images/home/sponsors/c77b1d664f10a1c9cb19b97c6d8bd204-pronto-software.png" width="250"></a>
-    <a href="https://civiform.us/"><img src="https://www.playframework.com/assets/images/home/sponsors/cb047b3782866c962c4d6a35b056b809-civiform.png" width="250"></a>
     <a href="https://theguardian.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/b15eb0f249dbc45089872e268d8ea5ad-the_guardian.png" width="250"></a>
   </div>
   


### PR DESCRIPTION
They handed over the Play project to another company, that company might take over sponsorship as well, we will see :crossed_fingers: 