### PR TITLE
Add support for coursier --jvm-index in workflows using java

### DIFF
--- a/.github/workflows/binary-check.yml
+++ b/.github/workflows/binary-check.yml
@@ -11,6 +11,10 @@ on:
         type: string
         required: false
         default: 11
+      java-index:
+        type: string
+        required: false
+        default: ''
       run-scheduled-in-forks:
         type: boolean
         required: false
@@ -40,6 +44,7 @@ jobs:
         uses: coursier/setup-action@v1
         with:
           jvm: adoptium:${{ inputs.java }}
+          jvm-index: ${{ inputs.java-index }}
 
       - name: Binary Compatibility
         run: sbt +mimaReportBinaryIssues

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -11,6 +11,10 @@ on:
         type: string
         required: false
         default: "11"
+      java-index:
+        type: string
+        required: false
+        default: ''
       scala:
         type: string
         required: false
@@ -123,6 +127,7 @@ jobs:
         uses: coursier/setup-action@v1
         with:
           jvm: adoptium:${{ matrix.java }}
+          jvm-index: ${{ inputs.java-index }}
 
       - name: Print helpful configs and files and show environment
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ on:
         type: string
         required: false
         default: 11
+      java-index:
+        type: string
+        required: false
+        default: ''
       cmd:
         type: string
         required: false
@@ -50,6 +54,7 @@ jobs:
         uses: coursier/setup-action@v1
         with:
           jvm: adoptium:${{ inputs.java }}
+          jvm-index: ${{ inputs.java-index }}
 
       - name: Publish artifacts
         run: ${{ inputs.cmd }}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Every matrix dimension will be access by environment variable like `MATRIX_$(upp
 | ref                    | 2.0.0 | :heavy_minus_sign: | ''      | Branch, tag or SHA for checkout                 |
 | cmd                    | 2.0.0 | :exclamation:      | -       | Running command                                 |
 | java                   | 2.0.0 | :heavy_minus_sign: | 11      | _AdoptJDK_ version (space/comma delimited list) |
+| java-index             | 3.3.1 | :heavy_minus_sign: | ''      | URL to JVM index source file                    |
 | scala                  | 2.0.0 | :heavy_minus_sign: | ''      | _Scala_ version (space/comma delimited list)    |
 | add-dimensions         | 2.0.0 | :heavy_minus_sign: | ''      | Other matrix dimensions (json object)           |
 | include                | 2.0.0 | :heavy_minus_sign: | []      | Matrix include's (json object array)            |
@@ -63,6 +64,7 @@ Every matrix dimension will be access by environment variable like `MATRIX_$(upp
 uses: playframework/.github/.github/workflows/cmd.yml@v3
 with:
   java: 17, 11
+  java-index: https://url/of/your/index.json
   scala: 2.12.18, 2.13.12, 3.3.1
   add-dimensions: >-
     {
@@ -93,6 +95,7 @@ This workflow is used for publishing snapshots artifacts to [Sonatype Snapshots]
 |-------------------|-------|--------------------|----------------|---------------------------------|
 | ref               | 2.0.0 | :heavy_minus_sign: | ''             | Branch, tag or SHA for checkout |
 | java              | 1.0.0 | :heavy_minus_sign: | 11             | _AdoptJDK_ version              |
+| java-index        | 3.3.1 | :heavy_minus_sign: | ''             | URL to JVM index source file    |
 | cmd               | 3.3.0 | :heavy_minus_sign: | sbt ci-release | Running command                 |
 | gradle-build-root | 3.3.0 | :heavy_minus_sign: | ''             | Directory for Gradle builds     |
 
@@ -122,6 +125,7 @@ This workflow is used for validate binary compatibility the current version.
 |------------------------|-------|--------------------|---------|---------------------------------|
 | ref                    | 2.0.0 | :heavy_minus_sign: | ''      | Branch, tag or SHA for checkout |
 | java                   | 1.0.0 | :heavy_minus_sign: | 11      | _AdoptJDK_ version              |
+| java-index             | 3.3.1 | :heavy_minus_sign: | ''      | URL to JVM index source file    |
 | run-scheduled-in-forks | 3.1.1 | :heavy_minus_sign: | false   | Run by schedule in fork         |
 
 **How to use**:


### PR DESCRIPTION
See https://github.com/coursier/setup-action/pull/465, that PR has been released now: https://github.com/coursier/setup-action/releases/tag/v1.3.4