### PR TITLE
Add Depop as premium sponsor

### DIFF
--- a/.github/release-drafts/base.yml
+++ b/.github/release-drafts/base.yml
@@ -15,12 +15,15 @@ footer: |
   ## :heart: Thanks to our premium sponsors!
   
   <div align="center">
-    <a href="https://informaticon.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/49a3d5258c8e8b1daf5481eb9e00b898-informaticon-logo-black.png" width="250"></a>
-    <a href="https://cedarlakeventures.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/bec2b526c9ce52c051f9089a10044867-cedar-lake-ventures.png" width="250"></a>
-    <a href="https://nulab.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/6152e584aa8625eedca1c4accf8f8b63-nulab_logo_color.png" width="250"></a>
-    <a href="https://pronto.net/"><img src="https://www.playframework.com/assets/images/home/sponsors/c77b1d664f10a1c9cb19b97c6d8bd204-pronto-software.png" width="250"></a>
-    <a href="https://sprypoint.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/3fdf14f6369cf9d69f4a2a29ce26c2f8-sprypoint-logo-lrg-transparent.png" width="250"></a>
     <a href="https://theguardian.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/b15eb0f249dbc45089872e268d8ea5ad-the_guardian.png" width="250"></a>
+    <br>
+    <a href="https://pronto.net/"><img src="https://www.playframework.com/assets/images/home/sponsors/c77b1d664f10a1c9cb19b97c6d8bd204-pronto-software.png" width="250"></a>
+    <a href="https://depop.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/483f7622215dc240d6e6fc52fe167bc0-depop.pngg" width="250"></a>
+    <a href="https://cedarlakeventures.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/bec2b526c9ce52c051f9089a10044867-cedar-lake-ventures.png" width="250"></a>
+    <br>
+    <a href="https://informaticon.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/49a3d5258c8e8b1daf5481eb9e00b898-informaticon-logo-black.png" width="250"></a>
+    <a href="https://nulab.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/6152e584aa8625eedca1c4accf8f8b63-nulab_logo_color.png" width="250"></a>
+    <a href="https://sprypoint.com/"><img src="https://www.playframework.com/assets/images/home/sponsors/3fdf14f6369cf9d69f4a2a29ce26c2f8-sprypoint-logo-lrg-transparent.png" width="250"></a>
   </div>
   
   If you find this OSS project useful for work, please consider asking your company to support it by <a href="https://www.playframework.com/sponsors">becoming a sponsor</a>.


### PR DESCRIPTION
https://www.depop.com/ :partying_face: 

Official announcement follows by the end of this week.
I want to cut Play 3.0.6 before, but want to have their logo on the release notes already.

I also reordered the logos like in 

- https://github.com/playframework/playframework.com/pull/600

because we need a third row anyway (no preferences made really in ordering).