### PR TITLE
Run on `ubuntu-24.04`

### DIFF
--- a/.github/workflows/antora.yml
+++ b/.github/workflows/antora.yml
@@ -27,7 +27,7 @@ jobs:
       github.event.repository.fork == false || 
       github.event_name != 'schedule' || 
       (github.event_name == 'schedule' && github.event.repository.fork == true && inputs.run-scheduled-in-forks == true)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Block deprecated repos in /etc/hosts
         run: |

--- a/.github/workflows/binary-check.yml
+++ b/.github/workflows/binary-check.yml
@@ -35,7 +35,7 @@ jobs:
       github.event.repository.fork == false || 
       github.event_name != 'schedule' || 
       (github.event_name == 'schedule' && github.event.repository.fork == true && inputs.run-scheduled-in-forks == true)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Block deprecated repos in /etc/hosts
         run: |

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -74,7 +74,7 @@ jobs:
       github.event.repository.fork == false || 
       github.event_name != 'schedule' || 
       (github.event_name == 'schedule' && github.event.repository.fork == true && inputs.run-scheduled-in-forks == true)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.prepare-matrix.outputs.matrix }}
     steps:
@@ -99,7 +99,7 @@ jobs:
     name: ${{ toJSON(matrix) }}
     if: ${{ github.event.repository.fork == false || github.event_name != 'schedule' || (github.event_name == 'schedule' && github.event.repository.fork == true && inputs.run-scheduled-in-forks == true) }}
     needs: prepare-matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       # WA: https://github.community/t/reusable-workflow-with-strategy-matrix/205676/6
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   cmd:
     name: Gradle Wrapper Validation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Block deprecated repos in /etc/hosts
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   cmd:
     name: JDK ${{ inputs.java }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event.repository.fork == false }}
     steps:
       - name: Block deprecated repos in /etc/hosts

--- a/.github/workflows/rtm.yml
+++ b/.github/workflows/rtm.yml
@@ -7,7 +7,7 @@ jobs:
   cmd:
     name: Ready To Merge
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Ready To Merge
         run: echo 'Ready To Merge'

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   sync:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
> 
>     March 4 14:00 UTC – 22:00 UTC
>     March 11 13:00 UTC – 21:00 UTC
>     March 18 13:00 UTC – 21:00 UTC
>     March 25 13:00 UTC – 21:00 UTC
> 
> What you need to do
> 
> Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest. You can always get up-to-date information on our tools by reading about the software in the [runner images repository](https://github.com/actions/runner-images).