### PR TITLE
Improve CMD task for matrix strategy

### DIFF
--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -15,22 +15,6 @@ on:
         type: string
         required: false
         default: ''
-      scala:
-        type: string
-        required: false
-        default: ""
-      add-dimensions:
-        type: string
-        required: false
-        default: "{}"
-      include:
-        type: string
-        required: false
-        default: "[]"
-      exclude:
-        type: string
-        required: false
-        default: "[]"
       cmd:
         type: string
         required: true
@@ -66,43 +50,15 @@ on:
         type: string
         required: false
         default: ""
+      gradle-cache-read-only:
+        type: boolean
+        required: false
+        default: false
 
 jobs:
-  prepare-matrix:
-    name: Prepare Matrix
-    if: >-
-      github.event.repository.fork == false || 
-      github.event_name != 'schedule' || 
-      (github.event_name == 'schedule' && github.event.repository.fork == true && inputs.run-scheduled-in-forks == true)
-    runs-on: ubuntu-24.04
-    outputs:
-      matrix: ${{ steps.prepare-matrix.outputs.matrix }}
-    steps:
-    - id: prepare-matrix
-      run: |
-        add_dimensions=$(echo -n '${{ inputs.add-dimensions }}' | sed 's/^.*{//;s/}.*$//') # Remove leading { and trailing }
-        # input java/scala | replace whitespaces/commas/quotes by newline | drop empty | quotation | join by comma
-        java=$(echo -n '${{inputs.java}}' | sed 's/[[:blank:],"]\+/\n/g' | awk NF | sed 's/^..*$/"&"/' | sed ':a; N; $!ba; s/\n/,/g')
-        scala=$(echo -n '${{inputs.scala}}' | sed 's/[[:blank:],"]\+/\n/g' | awk NF | sed 's/^..*$/"&"/' | sed ':a; N; $!ba; s/\n/,/g')
-        matrix="{"
-        matrix+="\"java\": [$java],"
-        [[ ! -z "$scala" ]] && matrix+="\"scala\": [$scala],"
-        matrix+="$(echo ${add_dimensions:+$add_dimensions,})"
-        matrix+="\"include\":$(echo -n '${{ inputs.include }}'),"
-        matrix+="\"exclude\":$(echo -n '${{ inputs.exclude }}')"
-        matrix+="}"
-        # Cleanup JSON (no unnecessary whitespaces, etc.)
-        matrix=$(jq -n -c "$matrix")
-        echo $matrix
-        echo "matrix=$matrix" >> $GITHUB_OUTPUT
   cmd:
-    name: ${{ toJSON(matrix) }}
     if: ${{ github.event.repository.fork == false || github.event_name != 'schedule' || (github.event_name == 'schedule' && github.event.repository.fork == true && inputs.run-scheduled-in-forks == true) }}
-    needs: prepare-matrix
     runs-on: ubuntu-24.04
-    strategy:
-      # WA: https://github.community/t/reusable-workflow-with-strategy-matrix/205676/6
-      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
     steps:
       - name: Block deprecated repos in /etc/hosts
         run: |
@@ -129,24 +85,26 @@ jobs:
 
       - name: Gradle Cache
         uses: burrunan/gradle-cache-action@v3
+        if: ${{ hashFiles(format('{0}{1}{2}', inputs.gradle-build-root, inputs.gradle-build-root && '/' || '', 'gradle/wrapper/gradle-wrapper.properties')) != '' }}
         with:
           build-root-directory: ${{ inputs.gradle-build-root }}
           # Disable caching of ~/.gradle/caches/build-cache-*
           save-local-build-cache: false
           # Disable caching of ~/.m2/repository/
           save-maven-dependencies-cache: false
+          read-only: ${{ inputs.gradle-cache-read-only }}
 
       - name: Custom Cache
         uses: actions/cache@v4
         if: ${{ inputs.cache-key != '' && inputs.cache-path != '' }}
         with:
-          key: ${{ format(inputs.cache-key, matrix.java) }}
+          key: ${{ format(inputs.cache-key, inputs.java) }}
           path: ${{ inputs.cache-path }}
 
       - name: Install Adoptium Temurin OpenJDK
         uses: coursier/setup-action@v1
         with:
-          jvm: adoptium:${{ matrix.java }}
+          jvm: adoptium:${{ inputs.java }}
           jvm-index: ${{ inputs.java-index }}
 
       - name: Install sbt
@@ -154,7 +112,6 @@ jobs:
 
       - name: Print helpful configs and files and show environment
         run: |
-          echo "Matrix: ${{ toJSON(matrix) }}"
           echo "$ cat /etc/sbt/jvmopts"
           cat /etc/sbt/jvmopts || true
           echo ""
@@ -167,10 +124,6 @@ jobs:
           ls -alFhR ~/.ivy2 | grep play | grep jar || true
           echo "ls -alFhR ~/.cache/coursier | grep play | grep jar"
           ls -alFhR ~/.cache/coursier | grep play | grep jar || true
-
-      - name: Convert matrix elements to environment variables
-        run: |
-          jq -n -r '$in | to_entries|map("MATRIX_\(.key|ascii_upcase)=\(.value|tostring)")|.[]' --argjson in '${{ toJSON(matrix) }}' >> $GITHUB_ENV
 
       - name: Run command
         run: ${{ inputs.cmd }}

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ This repository contains a few configurations of GitHub features. For example a 
 
 This workflow is used for running any CMD task on matrix of Java versions and other dimensions.
 
-Every matrix dimension will be access by environment variable like `MATRIX_$(uppercase(dimension_name))` (for example `MATRIX_JAVA`).
-
-
 **Path**: [`.github/workflows/cmd.yml`](.github/workflows/cmd.yml)
 
 **Image**: [Ubuntu 20.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md)
@@ -47,10 +44,6 @@ Every matrix dimension will be access by environment variable like `MATRIX_$(upp
 | cmd                          | 2.0.0 | :exclamation:      | -       | Running command                                 |
 | java                         | 2.0.0 | :heavy_minus_sign: | 17      | _AdoptJDK_ version (space/comma delimited list) |
 | java-index                   | 3.3.1 | :heavy_minus_sign: | ''      | URL to JVM index source file                    |
-| scala                        | 2.0.0 | :heavy_minus_sign: | ''      | _Scala_ version (space/comma delimited list)    |
-| add-dimensions               | 2.0.0 | :heavy_minus_sign: | ''      | Other matrix dimensions (json object)           |
-| include                      | 2.0.0 | :heavy_minus_sign: | []      | Matrix include's (json object array)            |
-| exclude                      | 2.0.0 | :heavy_minus_sign: | []      | Matrix exclude's (json object array)            |
 | cache-key                    | 2.0.0 | :heavy_minus_sign: | ''      | Key of custom cache                             |
 | cache-path                   | 2.0.0 | :heavy_minus_sign: | ''      | Path of custom cache                            |
 | env                          | 2.0.0 | :heavy_minus_sign: | ''      | Custom ENV vars                                 |
@@ -64,16 +57,17 @@ Every matrix dimension will be access by environment variable like `MATRIX_$(upp
 **How to use**:
 
 ```yaml
+strategy:
+  matrix:
+    java: [ 17, 21 ]
+    scala: [ 2.13.x, 3.x ]
+    color: [ "red", "green"]
 uses: playframework/.github/.github/workflows/cmd.yml@v3
 with:
-  java: 17, 21
+  java: ${{ matrix.java }}
+  scala: ${{ matrix.scala }}
   java-index: https://url/of/your/index.json
-  scala: 2.12.19, 2.13.13, 3.3.1
-  add-dimensions: >-
-    {
-      "color": [ "red", "green"]
-    }
-  cmd: sbt "-Dcustom_var=$CUSTOM_VAR" "-Dcolor=$MATRIX_COLOR" "-Djava=$MATRIX_JAVA" ++$MATRIX_SCALA test
+  cmd: sbt "-Dcustom_var=$CUSTOM_VAR" "-Dcolor=${{ matrix.color }}" "-Djava=${{ matrix.java }}" ++${{ matrix.scala }} test
   env: |
     CUSTOM_VAR=value
 ```


### PR DESCRIPTION
What the history? 📝 

1. In 2022 we had a problem with reusable workflow and matrix strategy (link already is broken https://github.community/t/reusable-workflow-with-strategy-matrix/205676/6)
2. We implemented a special trick (#19) in May 2022.
3. In August 2022 GitHub [had solved this problem](https://github.blog/changelog/2022-08-22-github-actions-improvements-to-reusable-workflows-2/) but we missed this news.

So, we can use out-of-the-box feature of GitHub actions now and dramatically simplify our CMD task. Current documentation about using reusable workflow with matrix is here https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-a-matrix-strategy-with-a-reusable-workflow

@mkurz WDYT?

PS: I checked a new version for our core repo [15163869490](https://github.com/ihostage/playframework/actions/runs/15163869490). Moreover, I think the summary page for action looks more compacted now.
