### PR TITLE
[3.x] Upgrade various GitHub actions we depend on

### DIFF
--- a/.github/workflows/antora.yml
+++ b/.github/workflows/antora.yml
@@ -34,13 +34,13 @@ jobs:
           sudo echo "127.0.0.1 repo.scala-sbt.org" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 repo.typesafe.com" | sudo tee -a /etc/hosts
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
       - name: Install NodeJS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -48,7 +48,7 @@ jobs:
         id: npm-cache-dir
         run: |
           echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}

--- a/.github/workflows/binary-check.yml
+++ b/.github/workflows/binary-check.yml
@@ -42,7 +42,7 @@ jobs:
           sudo echo "127.0.0.1 repo.scala-sbt.org" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 repo.typesafe.com" | sudo tee -a /etc/hosts
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -50,14 +50,14 @@ jobs:
 
       - name: Coursier Cache
         id: coursier-cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           ignoreJob: ${{ inputs.ignore-job-coursier-cache }}
           ignoreMatrix: true
           extraKey: ${{ inputs.extra-coursier-cache-key }}
 
       - name: Install Adoptium Temurin OpenJDK
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: adoptium:${{ inputs.java }}
           jvm-index: ${{ inputs.java-index }}

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -109,7 +109,7 @@ jobs:
           sudo echo "127.0.0.1 repo.scala-sbt.org" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 repo.typesafe.com" | sudo tee -a /etc/hosts
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -121,14 +121,14 @@ jobs:
 
       - name: Coursier Cache
         id: coursier-cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           ignoreJob: ${{ inputs.ignore-job-coursier-cache }}
           ignoreMatrix: ${{ inputs.ignore-matrix-coursier-cache }}
           extraKey: ${{ inputs.extra-coursier-cache-key }}
 
       - name: Gradle Cache
-        uses: burrunan/gradle-cache-action@v2
+        uses: burrunan/gradle-cache-action@v3
         with:
           build-root-directory: ${{ inputs.gradle-build-root }}
           # Disable caching of ~/.gradle/caches/build-cache-*
@@ -137,14 +137,14 @@ jobs:
           save-maven-dependencies-cache: false
 
       - name: Custom Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         if: ${{ inputs.cache-key != '' && inputs.cache-path != '' }}
         with:
           key: ${{ format(inputs.cache-key, matrix.java) }}
           path: ${{ inputs.cache-path }}
 
       - name: Install Adoptium Temurin OpenJDK
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: adoptium:${{ matrix.java }}
           jvm-index: ${{ inputs.java-index }}

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -18,11 +18,11 @@ jobs:
           sudo echo "127.0.0.1 repo.scala-sbt.org" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 repo.typesafe.com" | sudo tee -a /etc/hosts
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
           ref: ${{ inputs.ref }}
 
       - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
           sudo echo "127.0.0.1 repo.scala-sbt.org" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 repo.typesafe.com" | sudo tee -a /etc/hosts
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -51,14 +51,14 @@ jobs:
 
       - name: Coursier Cache
         id: coursier-cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           ignoreJob: ${{ inputs.ignore-job-coursier-cache }}
           ignoreMatrix: true
           extraKey: ${{ inputs.extra-coursier-cache-key }}
 
       - name: Gradle Cache
-        uses: burrunan/gradle-cache-action@v2
+        uses: burrunan/gradle-cache-action@v3
         with:
           build-root-directory: ${{ inputs.gradle-build-root }}
           # Disable caching of ~/.gradle/caches/build-cache-*
@@ -67,7 +67,7 @@ jobs:
           save-maven-dependencies-cache: false
 
       - name: Install Adoptium Temurin OpenJDK
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: adoptium:${{ inputs.java }}
           jvm-index: ${{ inputs.java-index }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@v1
         with:


### PR DESCRIPTION
Backports

* Update gradle-cache-action by @mkurz in https://github.com/playframework/.github/pull/100
* Bump actions/checkout from 4 to 5 by @dependabot[bot] in https://github.com/playframework/.github/pull/104
* Bump actions/setup-node from 4 to 5 by @dependabot[bot] in https://github.com/playframework/.github/pull/105
* Bump gradle/actions from 4 to 5 by @dependabot[bot] in https://github.com/playframework/.github/pull/106
* Bump actions/setup-node from 5 to 6 by @dependabot[bot] in https://github.com/playframework/.github/pull/107
* Bump coursier/cache-action from 6 to 7 by @dependabot[bot] in https://github.com/playframework/.github/pull/108
* Bump actions/checkout from 5 to 6 by @dependabot[bot] in https://github.com/playframework/.github/pull/109
* Bump coursier/setup-action from 1 to 2 by @dependabot[bot] in https://github.com/playframework/.github/pull/110
* Bump actions/cache from 4 to 5 by @dependabot[bot] in https://github.com/playframework/.github/pull/111
* Bump coursier/setup-action from 2 to 3 by @dependabot[bot] in https://github.com/playframework/.github/pull/114
* Bump coursier/cache-action from 7 to 8 by @dependabot[bot] in https://github.com/playframework/.github/pull/112
* Bump gradle/actions from 5 to 6 by @dependabot[bot] in https://github.com/playframework/.github/pull/115